### PR TITLE
UNTESTED: use putValue instead of putString

### DIFF
--- a/driverStationServer.py
+++ b/driverStationServer.py
@@ -53,7 +53,7 @@ class WebSocket(tornado.websocket.WebSocketHandler):
         subtable=self.sd.getSubTable(tableName)
         print('SubtableWrite, key-',key,',message-',newMessage,',tableName ',tableName)
         #subtable.putString(key, newMessage)
-        subtable.putString(key, newMessage)      #this line writes to subtable but breaks code
+        subtable.putValue(key, newMessage)      #this line writes to subtable but breaks code
         #self.sd.putString(key, newMessage)
     def on_close(self):
         print("WebSocket closed")
@@ -94,12 +94,12 @@ class WebSocket(tornado.websocket.WebSocketHandler):
         key=message['key']
         newMessage=message["value"]
         print('key-',key,',message-',newMessage)
-        self.sd.putString(key, newMessage)
+        self.sd.putValue(key, newMessage)
 
     def writeStringToNetworkTable(self, key,message):#key is a string, message is a string
 
         print('key-',key,',message-',message)
-        self.sd.putString(key, message)
+        self.sd.putValue(key, message)
 
 
 


### PR DESCRIPTION
@lleontan you need to be sending the _right_ values down to the code. We will NOT convert strings to boolean/integer/whatever -- that's unnecessary work the robot code shouldn't need to do. Send the proper values down, or things will break.

Thankfully, this is easy to do. If you use 'putValue', then it will detect the right type -- provided you send the right type in JSON. So make sure that when you send values down in messages, that they are the proper javascript type (number, str, boolean), and it should be deserialized in python as the proper type, and putValue should put the proper type through. 

But test it out, and find where you accidentally convert things to strings that you shouldn't convert to strings.
