### PR TITLE
Update readme to refer to DriverStationServer not driverStationClientV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Connect to the robot
 
 Run this command:
 
-    python3 driverStationClientV1.py --host=roborio-1418.local
+    python3 driverStationServer.py --host=roborio-1418.local
 
 View the output
 ---------------


### PR DESCRIPTION
Hello!

We're looking at the possibility of doing something similar this year. I was confused by this instruction but found this commit where the file name was changed: https://github.com/frc1418/2015-ui/commit/689a0e21fbb07b9d881453c907b2b77324bb243a

I think this update is the intended instruction?
